### PR TITLE
fix: Allow HTTP via IMMICH_ALLOW_INSECURE_HTTP configuration for internal networks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immich-album-downloader",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "CLI tool for downloading and backing up Immich albums with resume support, filtering, and Docker support.",
   "packageManager": "bun@1.2.21",
   "type": "module",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -48,7 +48,7 @@ function firstDefined(...values) {
   return values.find((value) => value !== undefined);
 }
 
-export function validateConfig(input: Partial<AppConfig>): AppConfig {
+export function validateConfig(input: Partial<AppConfig>, env = process.env): AppConfig {
   if (!input.apiKey) {
     throw new ConfigurationError(
       "Missing IMMICH_API_KEY. Set --api-key, IMMICH_API_KEY, or run interactively to configure it. Example: immich-album-downloader --base-url https://immich.example.com --api-key your-api-key --all"
@@ -72,8 +72,14 @@ export function validateConfig(input: Partial<AppConfig>): AppConfig {
     throw new ConfigurationError(`IMMICH_BASE_URL must be a valid URL. Got: ${input.baseUrl}`);
   }
 
-  if (process.env.NODE_ENV === "production" && baseUrl.protocol !== "https:") {
-    throw new ConfigurationError("IMMICH_BASE_URL must use HTTPS in production environment");
+  if (env.NODE_ENV === "production" && baseUrl.protocol !== "https:") {
+    const allowInsecure = env.IMMICH_ALLOW_INSECURE_HTTP === "true";
+
+    if (!allowInsecure) {
+      throw new ConfigurationError(
+        "IMMICH_BASE_URL must use HTTPS in production environment. Set IMMICH_ALLOW_INSECURE_HTTP=true to allow HTTP for internal/private networks."
+      );
+    }
   }
 
   const config = {
@@ -126,12 +132,12 @@ export async function resolveConfig(argv = {}, env = process.env): Promise<AppCo
 
   if ((!merged.apiKey || !merged.baseUrl) && process.stdin.isTTY && argv["interactive"] !== false) {
     const prompted = await promptForConfig(merged);
-    const config = validateConfig({ ...merged, ...prompted });
+    const config = validateConfig({ ...merged, ...prompted }, env);
     config.saveConfig = prompted.saveConfig;
     return config;
   }
 
-  const config = validateConfig(merged);
+  const config = validateConfig(merged, env);
   config.saveConfig = merged.saveConfig;
   return config;
 }

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -128,4 +128,29 @@ describe("config", () => {
     );
     expect(fs.readFileSync(".env", "utf8")).toBe("UNKNOWN=kept\n");
   });
+
+  test("blocks HTTP in production by default", () => {
+    expect(() =>
+      validateConfig(
+        { apiKey: env.IMMICH_API_KEY, baseUrl: "http://example.com/api" },
+        { NODE_ENV: "production" }
+      )
+    ).toThrow("IMMICH_BASE_URL must use HTTPS in production environment");
+  });
+
+  test("allows HTTP when IMMICH_ALLOW_INSECURE_HTTP=true", () => {
+    const config = validateConfig(
+      { apiKey: env.IMMICH_API_KEY, baseUrl: "http://immich-server:2283/api" },
+      { NODE_ENV: "production", IMMICH_ALLOW_INSECURE_HTTP: "true" }
+    );
+    expect(config.baseUrl).toBe("http://immich-server:2283/api");
+  });
+
+  test("allows HTTP in non-production environments", () => {
+    const config = validateConfig(
+      { apiKey: env.IMMICH_API_KEY, baseUrl: "http://example.com/api" },
+      { NODE_ENV: "development" }
+    );
+    expect(config.baseUrl).toBe("http://example.com/api");
+  });
 });


### PR DESCRIPTION
- Remove automatic private address detection
- Add IMMICH_ALLOW_INSECURE_HTTP=true environment variable for explicit HTTP bypass
- Update error message to guide users to the bypass option
- Keep HTTPS enforcement as default in production
- Add tests for HTTP bypass configuration

This allows users to explicitly opt-in to HTTP connections for internal/private networks (e.g., Docker) by setting IMMICH_ALLOW_INSECURE_HTTP=true, while maintaining HTTPS as the default security requirement.

Fixes issue #7: Enable HTTP connections for Docker internal networks

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S9W78AMFNNLY8jRxyPDvPY